### PR TITLE
Allow disabling for specific sites

### DIFF
--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -53,8 +53,20 @@ class CheckPassword implements MiddlewareInterface
         RequestHandlerInterface $handler
     ): ResponseInterface {
 
-        /** Skip if no password defined */
-        if (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) {
+        $site = $request->getAttribute('site');
+        if(
+            /** If no password defined */
+            (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) ||
+            /** Or if globalPassword is disabled in site config */
+            (
+                $site &&
+                isset(
+                    $site->getConfiguration()['globalPassword'],
+                    $site->getConfiguration()['globalPassword']['enabled'],
+                ) &&
+                $site->getConfiguration()['globalPassword']['enabled'] === false
+            )
+        ) {
             return $this->responseToMiddleware($request, $handler);
         }
 
@@ -64,10 +76,6 @@ class CheckPassword implements MiddlewareInterface
         ) {
             $this->removePasswordCookie();
             return new RedirectResponse('/');
-        }
-
-        if (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) {
-            return $this->responseToMiddleware($request, $handler);
         }
 
         /** @var \TYPO3\CMS\Extbase\Object\ObjectManager; objectManager */

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -60,6 +60,7 @@ class CheckPassword implements MiddlewareInterface
             /** Or if globalPassword is disabled in site config */
             (
                 $site &&
+                method_exists($site, 'getConfiguration') &&
                 isset(
                     $site->getConfiguration()['globalPassword'],
                     $site->getConfiguration()['globalPassword']['enabled'],

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Password protection for a complete TYPO3 frontend. Useful for development and st
 `TYPO3__GLOBAL_PASSWORD="Password123!"`
 
 ### Config file name (optional):
+
 `TYPO3__GLOBAL_PASSWORD_CONFIG_FILE="global-password.yaml"`
 
 save config file to `config` directory
@@ -32,6 +33,15 @@ texts:
 
 add this get parameter to your url:
 ``?global-password-logout=1``
+
+## Site specific
+
+If you have a multi-site install you may wish to disable the password for a particular site. This can be done by adding the following to you site config file (e.g. `config/sites/XXX/config.yaml`)
+
+```yaml
+globalPassword:
+  enabled: false
+```
 
 Copyright (c) 2019 Bastian Schwabe <bas@neuedaten.de>
 


### PR DESCRIPTION
Thanks for the great extension - realised it hasn't been updated in a little while.

Had a recent example where a site went live but we wanted to password protect a second site in the same install.

This allows 

```yaml
globalPassword:
  enabled: false
```

To be added to the site config to disable the global password for that particular site