### PR TITLE
Allow password protection to be controlled via the site

### DIFF
--- a/Classes/Entity/GlobalPasswordConfiguration.php
+++ b/Classes/Entity/GlobalPasswordConfiguration.php
@@ -1,0 +1,101 @@
+<?php
+namespace Neuedaten\GlobalPassword\Entity;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\ExpressionLanguage\Resolver;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
+
+/**
+ * GlobalPasswordConfiguration
+ *
+ * Parse the GlobalPassword Configuration in a site file
+ */
+class GlobalPasswordConfiguration implements SingletonInterface
+{
+    protected $config = [];
+
+    /**
+     * __construct
+     *
+     * @param Site $site
+     */
+    public function __construct(Site $site)
+    {
+        // Do we have config set?
+        if (isset($site->getConfiguration()['globalPassword'])) {
+            $config = $site->getAttribute('globalPassword');
+
+            /**
+             * If there are conditional variants separate them our and remove from config
+             */
+            if(isset($config['variants'])) {
+                $variants = $config['variants'];
+                unset($config['variants']);
+            }
+
+            // Merge the conditional config and global config
+            $this->config = $this->applyEnvironmentConfiguration($config, $variants);
+        }
+    }
+
+    /**
+     * isPasswordProtected
+     *
+     * Is the site (with environmental overrides) password protected?
+     *
+     * @return bool
+     */
+    public function isPasswordProtected(): bool
+    {
+        return $this->config['enabled'] ?? false;
+    }
+
+
+    /**
+     * applyEnvironmentConfiguration
+     *
+     * Apply environmental overrides to allow environment & site specific config
+     *
+     * This uses the same code found in \TYPO3\CMS\Core\Site\Entity\Site
+     *
+     * Here's an example of how to disable the password on dev
+     * <code>
+     * globalPassword:
+     *  enabled: true
+     *  variants:
+     *    -
+     *      enabled: false
+     *      condition: 'applicationContext == "Development/Local"'
+     * </code>
+     *
+     * @param array $config
+     * @param array $variants
+     */
+    protected function applyEnvironmentConfiguration(array $config, array $variants = [])
+    {
+        if(count($variants)) {
+            $expressionLanguageResolver = GeneralUtility::makeInstance(
+                Resolver::class,
+                'site',
+                []
+            );
+
+            foreach ($variants as $variant) {
+                try {
+                    if ($expressionLanguageResolver->evaluate($variant['condition'])) {
+                        unset($variant['condition']);
+                        $config = array_merge($config, $variant);
+                        break;
+                    }
+                } catch (SyntaxError $e) {
+                    // silently fail and do not evaluate
+                    // no logger here, as Site is currently cached and serialized
+                }
+            }
+        }
+
+        return $config;
+    }
+}

--- a/Classes/Entity/GlobalPasswordConfiguration.php
+++ b/Classes/Entity/GlobalPasswordConfiguration.php
@@ -36,7 +36,7 @@ class GlobalPasswordConfiguration implements SingletonInterface
             }
 
             // Merge the conditional config and global config
-            $this->config = $this->applyEnvironmentConfiguration($config, $variants);
+            $this->config = $this->applyEnvironmentConfiguration($config, $variants ?? []);
         }
     }
 
@@ -73,7 +73,7 @@ class GlobalPasswordConfiguration implements SingletonInterface
      * @param array $config
      * @param array $variants
      */
-    protected function applyEnvironmentConfiguration(array $config, array $variants = [])
+    protected function applyEnvironmentConfiguration(array $config, array $variants)
     {
         if(count($variants)) {
             $expressionLanguageResolver = GeneralUtility::makeInstance(

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -53,8 +53,20 @@ class CheckPassword implements MiddlewareInterface
         RequestHandlerInterface $handler
     ): ResponseInterface {
 
-        /** Skip if no password defined */
-        if (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) {
+        $site = $request->getAttribute('site');
+        if(
+            /** If no password defined */
+            (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) ||
+            /** Or if globalPassword is disabled in site config */
+            (
+                $site &&
+                isset(
+                    $site->getConfiguration()['globalPassword'],
+                    $site->getConfiguration()['globalPassword']['enabled'],
+                ) &&
+                $site->getConfiguration()['globalPassword']['enabled'] === false
+            )
+        ) {
             return $this->responseToMiddleware($request, $handler);
         }
 
@@ -64,10 +76,6 @@ class CheckPassword implements MiddlewareInterface
         ) {
             $this->removePasswordCookie();
             return new RedirectResponse('/');
-        }
-
-        if (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) {
-            return $this->responseToMiddleware($request, $handler);
         }
 
         /** @var \TYPO3\CMS\Extbase\Object\ObjectManager; objectManager */

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -60,6 +60,7 @@ class CheckPassword implements MiddlewareInterface
             /** Or if globalPassword is disabled in site config */
             (
                 $site &&
+                method_exists($site, 'getConfiguration') &&
                 isset(
                     $site->getConfiguration()['globalPassword'],
                     $site->getConfiguration()['globalPassword']['enabled'],

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -3,17 +3,18 @@ declare(strict_types=1);
 
 namespace Neuedaten\GlobalPassword\Middleware;
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\HtmlResponse;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3Fluid\Fluid\View\TemplateView;
+use Psr\Http\Server\MiddlewareInterface;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3Fluid\Fluid\View\TemplateView;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
+use Neuedaten\GlobalPassword\Entity\GlobalPasswordConfiguration;
 
 class CheckPassword implements MiddlewareInterface
 {
@@ -54,19 +55,11 @@ class CheckPassword implements MiddlewareInterface
     ): ResponseInterface {
 
         $site = $request->getAttribute('site');
+        $GlobalPasswordConfiguration = GeneralUtility::makeInstance(GlobalPasswordConfiguration::class, $site);
+
         if(
-            /** If no password defined */
             (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) ||
-            /** Or if globalPassword is disabled in site config */
-            (
-                $site &&
-                method_exists($site, 'getConfiguration') &&
-                isset(
-                    $site->getConfiguration()['globalPassword'],
-                    $site->getConfiguration()['globalPassword']['enabled'],
-                ) &&
-                $site->getConfiguration()['globalPassword']['enabled'] === false
-            )
+            !$GlobalPasswordConfiguration->isPasswordProtected()
         ) {
             return $this->responseToMiddleware($request, $handler);
         }

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -17,6 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Frontend\Page\PageAccessFailureReasons;
 use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
 use Neuedaten\GlobalPassword\Entity\GlobalPasswordConfiguration;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
 
 class CheckPassword implements MiddlewareInterface
 {

--- a/Classes/Middleware/CheckPassword.php
+++ b/Classes/Middleware/CheckPassword.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Neuedaten\GlobalPassword\Middleware;
 
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -13,6 +14,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Frontend\Page\PageAccessFailureReasons;
 use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
 use Neuedaten\GlobalPassword\Entity\GlobalPasswordConfiguration;
 
@@ -55,11 +57,20 @@ class CheckPassword implements MiddlewareInterface
     ): ResponseInterface {
 
         $site = $request->getAttribute('site');
-        $GlobalPasswordConfiguration = GeneralUtility::makeInstance(GlobalPasswordConfiguration::class, $site);
+
+        if (!$site instanceof Site) {
+            return GeneralUtility::makeInstance(ErrorController::class)->pageNotFoundAction(
+                $request,
+                'No site configuration found.',
+                ['code' => PageAccessFailureReasons::PAGE_NOT_FOUND]
+            );
+        }
+
+        $globalPasswordConfiguration = GeneralUtility::makeInstance(GlobalPasswordConfiguration::class, $site);
 
         if(
             (!array_key_exists(self::ENV_PASSWORD_FIELD, $_ENV)) ||
-            !$GlobalPasswordConfiguration->isPasswordProtected()
+            !$globalPasswordConfiguration->isPasswordProtected()
         ) {
             return $this->responseToMiddleware($request, $handler);
         }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Password protection for a complete TYPO3 frontend. Useful for development and staging servers.
 
+Set the password in your env file then configure if it is active or not via the site config
+
 ## .env
 
 ### Password:
@@ -14,11 +16,33 @@ Password protection for a complete TYPO3 frontend. Useful for development and st
 
 save config file to `config` directory
 
+## Site Configuration YAML
+
+To activate the password for that site on all environments **where the password is present** then add:
+
+```yaml
+globalPassword:
+  enabled: true
+```
+
+If you wish to disable/enable the password for a specific environment, you can do this with:
+
+```yaml
+globalPassword:
+  enabled: false
+  variants:
+    -
+      enabled: true
+      condition: 'applicationContext == "Production/Staging"'
+```
+
+Where `condition` is the same as the `baseVariants` conditions of the domain names
+
 ## Config file
 
 e.g. `config/global-password.yaml`
 
-```
+```yaml
 texts:
      title: "Page title"
      htmlAbove: "some text <b>above</b> the form"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Password protection for a complete TYPO3 frontend. Useful for development and st
 `TYPO3__GLOBAL_PASSWORD="Password123!"`
 
 ### Config file name (optional):
+
 `TYPO3__GLOBAL_PASSWORD_CONFIG_FILE="global-password.yaml"`
 
 save config file to `config` directory
@@ -32,6 +33,15 @@ texts:
 
 add this get parameter to your url:
 ``?global-password-logout=1``
+
+## Site specific
+
+If you have a multi-site install you may wish to disable the password for a particular site. This can be done by adding the following to you site config file (e.g. `config/sites/XXX/config.yaml`)
+
+```yaml
+globalPassword:
+  enabled: false
+```
 
 Copyright (c) 2019 Bastian Schwabe <bas@neuedaten.de>
 

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,32 @@
 {
-	"name": "neuedaten/global-password",
-	"type": "typo3-cms-extension",
-	"description": "Global TYPO3 frontend password protection",
-	"homepage": "https://www.neuedaten.de",
-	"license": ["GPL-2.0-or-later"],
-	"authors": [{
-		"name": "Bastian Schwabe",
-		"email": "bas@neuedaten.de",
-		"role": "Developer"
-	}],
-	"config": {
-		"sort-packages": true
-	},
-	"autoload": {
-		"psr-4": {
-			"Neuedaten\\GlobalPassword\\": "Classes/"
-		}
-	},
-	"require": {
+    "name": "neuedaten/global-password",
+    "description": "Global TYPO3 frontend password protection",
+    "type": "typo3-cms-extension",
+    "authors": [
+        {
+            "name": "Bastian Schwabe",
+            "email": "bas@neuedaten.de",
+            "role": "Developer"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Neuedaten\\GlobalPassword\\": "Classes/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "global_password"
+        }
+    },
+    "homepage": "https://www.neuedaten.de",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
         "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,9 @@
 		"psr-4": {
 			"Neuedaten\\GlobalPassword\\": "Classes/"
 		}
-	}
+	},
+	"require": {
+        "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
+    }
+
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99',
+            'typo3' => '9.5.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Once again, thanks for a handy extension!

**This MR is a breaking change**

Rather than assume all sites are password protected when the password is present, this enables configuration via the Site config file and so allows you to disable/enable depending on environment - especially useful in a multi-site setup.

**Site note:** If you no longer wish to maintain this package then I would be happy to adopt it