### PR TITLE
fix: Allow files to be found in vendor

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{texts.title}</title>
 
-    <link rel="stylesheet" type="text/css" href="/typo3conf/ext/global_password/Resources/Public/CSS/main.css" />
+    <link rel="stylesheet" type="text/css" href="{cssPathAndFilename}" />
 </head>
 <body>
 


### PR DESCRIPTION
From v12, files get loaded in the vendor folder - this can also be enabled in v11 with v4 of the typo3 composer loader.

This ensures files (and CSS) can correctly get loaded